### PR TITLE
Do not print URLs of links inside a table

### DIFF
--- a/css/pretty-vendor.83ac49e057c3eac4fce3.css
+++ b/css/pretty-vendor.83ac49e057c3eac4fce3.css
@@ -1463,6 +1463,7 @@ button.close { -webkit-appearance: none; padding: 0; cursor: pointer; background
  *, :after, :before { color: #000 !important; text-shadow: none !important; background: 0 0 !important; box-shadow: none !important; }
  a, a:visited { text-decoration: underline; }
  a[href]:after { content: " (" attr( href ) ")"; }
+ table a[href]::after { content: " (\1f517)"; }
  abbr[title]:after { content: " (" attr( title ) ")"; }
  a[href^="javascript:"]:after, a[href^="#"]:after { content: ""; }
  blockquote, pre { border: 1px solid #999; page-break-inside: avoid; }


### PR DESCRIPTION
Printing URLs via `a:after` in a `@media print` is generally convenient for readers of hard-copy.
Printing URLs inside a datatable is less convenient - it breaks table formatting.

This change replaces in-table appended URLs with :link: unicode characters - adding a cue for readers but not breaking the formatting.