### PR TITLE
[WIP]feat: Add dark mode support

### DIFF
--- a/publish.py
+++ b/publish.py
@@ -2,7 +2,6 @@
 import os, sys
 
 HEADER = """
-
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 
 <link rel="stylesheet" type="text/css" href="/css/common-vendor.b8ecfc406ac0b5f77a26.css">
@@ -30,37 +29,74 @@ HEADER = """
     font-family: MJXTEX;
     src: url("https://assets.hackmd.io/build/MathJax/fonts/HTML-CSS/TeX/woff/MathJax_Main-Regular.woff")
 }
-
 .math { font-family: MJXc-TeX-math-Iw }
 </style>
 
 <div id="doc" class="container-fluid markdown-body comment-enabled" data-hard-breaks="true">
 
+<div id="color-mode-switch">
+    <span>Enable Dark Mode</span>
+    <input type="checkbox" id="switch" />
+    <label for="switch">Dark Mode Toggle</label>
+</div>
 """
 
-FOOTER = """ </div> """
+FOOTER = """</div>"""
 
 TOC_HEADER = """
-
 <br>
 <h1>{}</h1>
 <br>
 <br>
 <ul class="post-list">
-
 """
 
-TOC_FOOTER = """ </ul> """
+TOC_FOOTER = """</ul>"""
 
 TOC_ITEM_TEMPLATE = """
-
 <li>
     <span class="post-meta">{}</span>
     <h3>
       <a class="post-link" href="{}">{}</a>
     </h3>
 </li>
+"""
 
+TOGGLE_COLOR_SCHEME_JS = """
+<script type="text/javascript">
+  // Update root html class to set CSS colors
+  const toggleDarkMode = () => {
+    const root = document.querySelector('html');
+    root.classList.toggle('dark');
+  }
+
+  // Update local storage value for colorScheme
+  const toggleColorScheme = () => {
+    const colorScheme = localStorage.getItem('colorScheme');
+    if (colorScheme === 'light') localStorage.setItem('colorScheme', 'dark');
+    else localStorage.setItem('colorScheme', 'light');
+  }
+
+  // Set toggle input handler
+  const toggle = document.querySelector('#color-mode-switch input[type="checkbox"]');
+  if (toggle) toggle.onclick = () => {
+    toggleDarkMode();
+    toggleColorScheme();
+  }
+
+  // Check for color scheme on init
+  const checkColorScheme = () => {
+    const colorScheme = localStorage.getItem('colorScheme');
+    // Default to light for first view
+    if (colorScheme === null || colorScheme === undefined) localStorage.setItem('colorScheme', 'light');
+    // If previously saved to dark, toggle switch and update colors
+    if (colorScheme === 'dark') {
+      toggle.checked = true;
+      toggleDarkMode();
+    }
+  }
+  checkColorScheme();
+</script>
 """
 
 TWITTER_CARD_TEMPLATE = """
@@ -142,7 +178,8 @@ if __name__ == '__main__':
             HEADER +
             make_twitter_card(metadata, global_config) +
             defancify(open('/tmp/temp_output.html').read()) +
-            FOOTER
+            FOOTER +
+            TOGGLE_COLOR_SCHEME_JS
         )
 
         # Put it in the desired location
@@ -162,7 +199,8 @@ if __name__ == '__main__':
         make_twitter_card(global_config, global_config) +
         TOC_HEADER.format(global_config['title']) +
         ''.join(toc_items) +
-        TOC_FOOTER
+        TOC_FOOTER +
+        TOGGLE_COLOR_SCHEME_JS
     )
 
     open('site/index.html', 'w').write(toc)

--- a/publish.py
+++ b/publish.py
@@ -10,6 +10,7 @@ HEADER = """
 <link rel="stylesheet" type="text/css" href="/css/fretboard.f32f2a8d5293869f0195.css">
 <link rel="stylesheet" type="text/css" href="/css/pretty.0ae3265014f89d9850bf.css">
 <link rel="stylesheet" type="text/css" href="/css/pretty-vendor.83ac49e057c3eac4fce3.css">
+<link rel="stylesheet" type="text/css" href="/css/global.css">
 <link rel="stylesheet" type="text/css" href="/css/misc.css">
 
 <script type="text/javascript" id="MathJax-script" async
@@ -121,21 +122,21 @@ if __name__ == '__main__':
     for file_location in sys.argv[1:]:
         filename = os.path.split(file_location)[1]
         print("Processing file: {}".format(filename))
-        
+
         # Extract path
         file_data = open(file_location).read()
         metadata = extract_metadata(open(file_location), filename)
         path = metadata_to_path(metadata)
         print("Path selected: {}".format(path))
-        
+
         # Make sure target directory exists
         truncated_path = os.path.split(path)[0]
         os.system('mkdir -p {}'.format(os.path.join('site', truncated_path)))
-        
+
         # Generate the html file
         out_location = os.path.join('site', path)
         options = metadata.get('pandoc', '')
-        
+
         os.system('pandoc -o /tmp/temp_output.html {} {}'.format(file_location, options))
         total_file_contents = (
             HEADER +
@@ -143,7 +144,7 @@ if __name__ == '__main__':
             defancify(open('/tmp/temp_output.html').read()) +
             FOOTER
         )
-    
+
         # Put it in the desired location
         open(out_location, 'w').write(total_file_contents)
 

--- a/site/css/global.css
+++ b/site/css/global.css
@@ -24,15 +24,15 @@ html, body {
 	color: var(--color-text);
 }
 
-h1, h2, h3, h4, h5, h6 {
+#doc h1, #doc h2, #doc h3, #doc h4, #doc h5, #doc h6 {
 	color: var(--color-heading);
 }
 
-p, li, div, span, th, td, dd, dl {
+#doc, #doc div, #doc span, #doc p, #doc li, #doc th, #doc td, #doc dd, #doc dl {
 	color: var(--color-text);
 }
 
-a:link, a:visited, a:active, a:checked {
+#doc a:link, #doc a:visited, #doc a:active, #doc a:checked {
 	color: var(--color-anchor);
 }
 

--- a/site/css/global.css
+++ b/site/css/global.css
@@ -1,0 +1,121 @@
+
+/* Light Mode Colors */
+:root {
+	--color-text: #333;
+	--color-bg: #fafafa;
+	--color-heading: #333;
+	--color-divider: #e7e7e7;
+	--color-anchor: #337ab7;
+	--color-toggle-checked: #9740f6;
+}
+
+/* Dark Mode Colors */
+html.dark {
+	--color-text: #fafafa;
+	--color-bg: #1c1c1c;
+	--color-heading: #dfdfdf;
+	--color-divider: #393939;
+	--color-anchor: #77e1cd;
+}
+
+/* Global colors */
+html, body {
+	background-color: var(--color-bg);
+	color: var(--color-text);
+}
+
+h1, h2, h3, h4, h5, h6 {
+	color: var(--color-heading);
+}
+
+p, li, div, span, th, td, dd, dl {
+	color: var(--color-text);
+}
+
+a:link, a:visited, a:active, a:checked {
+	color: var(--color-anchor);
+}
+
+.markdown-body hr {
+	background-color: var(--color-divider);
+}
+
+/* Light/Dark Mode Toggle */
+#color-mode-switch {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+}
+
+#color-mode-switch > span {
+	font-size: 30px;
+	display: inline-block;
+	margin-right: 8px;
+}
+
+#color-mode-switch input[type=checkbox] {
+	height: 0;
+	width: 0;
+	visibility: hidden;
+}
+
+#color-mode-switch label {
+	cursor: pointer;
+	text-indent: -9999px;
+	width: 60px;
+	height: 30px;
+	background: grey;
+	display: block;
+	border-radius: 30px;
+	position: relative;
+	margin: 0;
+}
+
+#color-mode-switch label:after {
+	content: '';
+	position: absolute;
+	top: 5px;
+	left: 5px;
+	width: 20px;
+	height: 20px;
+	background: #fff;
+	border-radius: 90px;
+	transition: 0.3s;
+}
+
+#color-mode-switch input:checked + label {
+	background: var(--color-toggle-checked);
+}
+
+#color-mode-switch input:checked + label:after {
+	left: calc(100% - 5px);
+	transform: translateX(-100%);
+}
+
+#color-mode-switch label:active:after {
+	width: 30px;
+}
+
+@media screen and (min-width: 1273px) {
+	#color-mode-switch > span {
+		font-size: 16px;
+	}
+
+	#color-mode-switch label {
+		width: 42px;
+		height: 21px;
+		border-radius: 30px;
+	}
+
+	#color-mode-switch label:after {
+		top: 3px;
+		left: 3px;
+		width: 15px;
+		height: 15px;
+	}
+
+
+	#color-mode-switch input:checked + label:after {
+		left: calc(100% - 3px);
+	}
+}

--- a/site/index.html
+++ b/site/index.html
@@ -28,7 +28,6 @@
 <link rel="stylesheet" type="text/css" href="./css/fretboard.f32f2a8d5293869f0195.css">
 <link rel="stylesheet" type="text/css" href="./css/pretty.0ae3265014f89d9850bf.css">
 <link rel="stylesheet" type="text/css" href="./css/pretty-vendor.83ac49e057c3eac4fce3.css">
-<link rel="stylesheet" type="text/css" href="./css/global.css">
 <link rel="stylesheet" type="text/css" href="./css/misc.css">
 
 <script type="text/x-mathjax-config">
@@ -57,12 +56,6 @@ MathJax = {
 <meta name="twitter:image" content="http://vitalik.ca/images/icon.png" />
 
 <title> Vitalik Buterin's website </title>
-
-<div id="color-mode-switch">
-  <span>Enable Dark Mode</span>
-  <input type="checkbox" id="switch" />
-  <label for="switch">Dark Mode Toggle</label>
-</div>
 
 <br>
 
@@ -819,38 +812,3 @@ MathJax = {
 </li>
 
  </ul>
-
-<script type="text/javascript">
-  // Update root html class to set CSS colors
-  const toggleDarkMode = () => {
-    const root = document.querySelector('html');
-    root.classList.toggle('dark');
-  }
-
-  // Update local storage value for colorScheme
-  const toggleColorScheme = () => {
-    const colorScheme = localStorage.getItem('colorScheme');
-    if (colorScheme === 'light') localStorage.setItem('colorScheme', 'dark');
-    else localStorage.setItem('colorScheme', 'light');
-  }
-
-  // Set toggle input handler
-  const toggle = document.querySelector('#color-mode-switch input[type="checkbox"]');
-  if (toggle) toggle.onclick = () => {
-    toggleDarkMode();
-    toggleColorScheme();
-  }
-
-  // Check for color scheme on init
-  const checkColorScheme = () => {
-    const colorScheme = localStorage.getItem('colorScheme');
-    // Default to light for first view
-    if (colorScheme === null || colorScheme === undefined) localStorage.setItem('colorScheme', 'light');
-    // If previously saved to dark, toggle switch and update colors
-    if (colorScheme === 'dark') {
-      toggle.checked = true;
-      toggleDarkMode();
-    }
-  }
-  checkColorScheme();
-</script>

--- a/site/index.html
+++ b/site/index.html
@@ -28,6 +28,7 @@
 <link rel="stylesheet" type="text/css" href="./css/fretboard.f32f2a8d5293869f0195.css">
 <link rel="stylesheet" type="text/css" href="./css/pretty.0ae3265014f89d9850bf.css">
 <link rel="stylesheet" type="text/css" href="./css/pretty-vendor.83ac49e057c3eac4fce3.css">
+<link rel="stylesheet" type="text/css" href="./css/global.css">
 <link rel="stylesheet" type="text/css" href="./css/misc.css">
 
 <script type="text/x-mathjax-config">
@@ -55,9 +56,16 @@ MathJax = {
 <meta name="twitter:title" content="Vitalik Buterin's website" />
 <meta name="twitter:image" content="http://vitalik.ca/images/icon.png" />
 
-
 <title> Vitalik Buterin's website </title>
+
+<div id="color-mode-switch">
+  <span>Enable Dark Mode</span>
+  <input type="checkbox" id="switch" />
+  <label for="switch">Dark Mode Toggle</label>
+</div>
+
 <br>
+
 <center><h1 style="border-bottom:0px"> Vitalik Buterin's website </h1></center>
 
 <center><hr>
@@ -810,4 +818,39 @@ MathJax = {
     </h3>
 </li>
 
- </ul> 
+ </ul>
+
+<script type="text/javascript">
+  // Update root html class to set CSS colors
+  const toggleDarkMode = () => {
+    const root = document.querySelector('html');
+    root.classList.toggle('dark');
+  }
+
+  // Update local storage value for colorScheme
+  const toggleColorScheme = () => {
+    const colorScheme = localStorage.getItem('colorScheme');
+    if (colorScheme === 'light') localStorage.setItem('colorScheme', 'dark');
+    else localStorage.setItem('colorScheme', 'light');
+  }
+
+  // Set toggle input handler
+  const toggle = document.querySelector('#color-mode-switch input[type="checkbox"]');
+  if (toggle) toggle.onclick = () => {
+    toggleDarkMode();
+    toggleColorScheme();
+  }
+
+  // Check for color scheme on init
+  const checkColorScheme = () => {
+    const colorScheme = localStorage.getItem('colorScheme');
+    // Default to light for first view
+    if (colorScheme === null || colorScheme === undefined) localStorage.setItem('colorScheme', 'light');
+    // If previously saved to dark, toggle switch and update colors
+    if (colorScheme === 'dark') {
+      toggle.checked = true;
+      toggleDarkMode();
+    }
+  }
+  checkColorScheme();
+</script>

--- a/site/index.html
+++ b/site/index.html
@@ -55,10 +55,9 @@ MathJax = {
 <meta name="twitter:title" content="Vitalik Buterin's website" />
 <meta name="twitter:image" content="http://vitalik.ca/images/icon.png" />
 
+
 <title> Vitalik Buterin's website </title>
-
 <br>
-
 <center><h1 style="border-bottom:0px"> Vitalik Buterin's website </h1></center>
 
 <center><hr>


### PR DESCRIPTION
# General Changes
- Adds in toggle markup that appears in top right of the header of each page
- Adds in styles for a clean look over the checkbox toggle in `global.css`
  - Utilizes CSS variables and styles the elements within the `#doc` container to use these variables for colors
  - There's a separate set for light and dark, which makes it easy to update these for a particular palette
- Adds in support to remember what a user's chosen preferred color scheme is by storing their choice in `localStorage`
- Adds in a the JavaScript needed to add the interactivity for the toggle switch and the styles
  - Checks `localStorage` for any previous saved value and applies it if so - defaults to light for new visitors
  - Toggles the global `dark` class on toggle switch click
  - Updates `localStorage` with the newly selected value
  
## Blocking Notes
 
This is currently a WIP - the changes need to be vetted over all of the individual post pages and clean up any misses that aren't caught by the current set of CSS selectors (images, captions, anything not obvious)

I'm unable to run `. /publish.py posts/*` effectively to compile the `.html` files correctly.  The files are not getting compiled into the proper spots within the filesystem.  Is this a bug elsewhere in the `publish.py` file?  Shouldn't these be compiled into `general/` and override the existing files as well as overriding `/index.html`?

It looks to be creating directories based off the comma-separated frontmatter field for `category`.  I have verified that my templates are indeed in the correct spots on these generated files, but it looks like just running the command also eliminates the primary navigation and post title/metadata.  I haven't made any changes to cause to the best to my knowledge.  I am following the directions outlined in [this readme](https://github.com/vbuterin/blogmaker#how-to-use).  Guidance around this will be very helpful!
  
See this video showing my woes:
https://www.loom.com/share/8bd1052d05994bf68891675563afa58c

And this video to show some my changes at work after running the above command. However, note the odd URL structure and removal of title/navigation:
https://www.loom.com/share/176c8c14d075461ba43f2a274b26bb19

Once I can get over this hurdle, I can very easily go over each individual post and verify that dark mode looks good and catch anything that my style selectors are missing.  Furthermore, I can then take the static files and put them up somewhere on a test URL that can be tested in a production-like environment, most likely using something like Heroku, or more simply, [Surge.sh](https://surge.sh).