### PR TITLE
Fix link title overflow issue

### DIFF
--- a/posts/zkevm.md
+++ b/posts/zkevm.md
@@ -77,7 +77,7 @@ The goal of a Type 3 ZK-EVM is to be compatible with _most_ applications, and re
 
 #### <span style="color:#880088">Who's building it?</span>
 
-Scroll and Polygon are both Type 3 in their current forms, though they're expected to improve compatibility over time. Polygon has a unique design where they are ZK-verifying their own internal language called [zkASM](https://github.com/0xPolygonHermez/zkevm-doc/blob/main/mkdocs/docs/zkEVM/zkASM/introduction.md), and they interpret ZK-EVM code using the zkASM implementation. Despite this implementation detail, I would still call this a genuine Type 3 ZK-EVM; it can still verify EVM code, it just uses some different internal logic to do it.
+Scroll and Polygon are both Type 3 in their current forms, though they're expected to improve compatibility over time. Polygon has a unique design where they are ZK-verifying their own internal language called [zkASM](https://github.com/0xPolygonHermez/zkevm-doc/blob/main/mkdocs/docs/zkEVM/zkASM/Introduction.md), and they interpret ZK-EVM code using the zkASM implementation. Despite this implementation detail, I would still call this a genuine Type 3 ZK-EVM; it can still verify EVM code, it just uses some different internal logic to do it.
 
 Today, no ZK-EVM team _wants_ to be a Type 3; Type 3 is simply a transitional stage until the complicated work of adding precompiles is finished and the project can move to Type 2.5. In the future, however, Type 1 or Type 2 ZK-EVMs may become Type 3 ZK-EVMs voluntarily, by adding in _new_ ZK-SNARK-friendly precompiles that provide functionality for developers with low prover times and gas costs.
 

--- a/site/css/misc.css
+++ b/site/css/misc.css
@@ -19,9 +19,7 @@
       display: inline-block;
       width: 85px;
       padding-top: 8px;
-      padding-bottom: 8px;
-      padding-right: 4px;
-      padding-left: 4px; }
+      padding-bottom: 8px; }
 }
 
 @media only screen and (orientation: portrait) {


### PR DESCRIPTION
As referenced in issue: https://github.com/vbuterin/blog/issues/42

The link titles overflow within the navigation due to too many characters.

![vitalik buterins website](https://user-images.githubusercontent.com/38789408/184816085-8d386b70-9973-470b-8075-c5346b1dab85.png)


My css fix edits the padding to prevent the words from overflowing onto 2 lines.

![vitalik ca fix](https://user-images.githubusercontent.com/38789408/184816237-41017a91-d060-4196-b845-a212ab8f8b88.png)


