### PR TITLE
Update broken link to external github page

### DIFF
--- a/posts/zkevm.md
+++ b/posts/zkevm.md
@@ -77,7 +77,7 @@ The goal of a Type 3 ZK-EVM is to be compatible with _most_ applications, and re
 
 #### <span style="color:#880088">Who's building it?</span>
 
-Scroll and Polygon are both Type 3 in their current forms, though they're expected to improve compatibility over time. Polygon has a unique design where they are ZK-verifying their own internal language called [zkASM](https://github.com/0xPolygonHermez/zkevm-doc/blob/main/mkdocs/docs/zkEVM/zkASM/introduction.md), and they interpret ZK-EVM code using the zkASM implementation. Despite this implementation detail, I would still call this a genuine Type 3 ZK-EVM; it can still verify EVM code, it just uses some different internal logic to do it.
+Scroll and Polygon are both Type 3 in their current forms, though they're expected to improve compatibility over time. Polygon has a unique design where they are ZK-verifying their own internal language called [zkASM](https://github.com/0xPolygonHermez/zkevm-doc/blob/main/mkdocs/docs/zkEVM/zkASM/Introduction.md), and they interpret ZK-EVM code using the zkASM implementation. Despite this implementation detail, I would still call this a genuine Type 3 ZK-EVM; it can still verify EVM code, it just uses some different internal logic to do it.
 
 Today, no ZK-EVM team _wants_ to be a Type 3; Type 3 is simply a transitional stage until the complicated work of adding precompiles is finished and the project can move to Type 2.5. In the future, however, Type 1 or Type 2 ZK-EVMs may become Type 3 ZK-EVMs voluntarily, by adding in _new_ ZK-SNARK-friendly precompiles that provide functionality for developers with low prover times and gas costs.
 


### PR DESCRIPTION
Slight error in the url to the external Github page resulting in a 404. Corrected in my fix: https://github.com/0xPolygonHermez/zkevm-doc/blob/main/mkdocs/docs/zkEVM/zkASM/Introduction.md