### PR TITLE
Use ENS version as canonical link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Vitalik's blog. Site at http://vitalik.ca
+Vitalik's blog. Site at http://vitalik.eth.limo
 
 Please feel free to make pull requests to the posts in the [posts](./posts/) directory if you see any fixes that need to be made! (Or contribute translations etc)
 


### PR DESCRIPTION
- Vitalik.ca is currently down
- We already seem to be treating eth.limo as the canonical link elsewhere (e.g., [Twitter](https://twitter.com/VitalikButerin/status/1691643403602407429))