### PR TITLE
typo fix Update cantor.md

### DIFF
--- a/posts/cantor.md
+++ b/posts/cantor.md
@@ -30,7 +30,7 @@ Now, here’s the fundamental flaw in this argument: *decimal expansions of real
 
 The diagonal gives: 01111….. If we flip every digit, we get the number: $y =$ 0.10000……
 
-And here lies the problem: just as in decimal, [0.9999…. equals 1](https://en.wikipedia.org/wiki/0.999...), in binary 0.01111….. equals 0.10000….. And so even though the new *decimal expansion *is not in the original list, the *number* $y$ is exactly the same as the number $x[2]$.
+And here lies the problem: just as in decimal, [0.9999…. equals 1](https://en.wikipedia.org/wiki/0.999...), in binary 0.01111….. equals 0.10000….. And so even though the new *decimal expansion *is not unique in the original list, the *number* $y$ is exactly the same as the number $x[2]$.
 
 Note that this directly implies that the halting problem is in fact solvable. To see why, imagine a computer program that someone claims will not halt. Let c[1] be the state of the program after one step, c[2] after two steps, etc. Let x[1], x[2], x[3]…. be a full enumeration of all real numbers (which exists, as we proved above), expressed in base $2^D$ where $D$ is the size of the program’s memory, so a program state can always be represented as a single “digit”. Let y = 0.c[1]c[2]c[3]…….. This number is by assumption part of the list, so it is one of the x[i] values, and hence it can be computed in some finite amount of time. This has implications in a number of industries, particularly in proving that “Turing-complete” blockchains are in fact secure.
 


### PR DESCRIPTION
The typo in the text is in the sentence:

*"decimal expansion is not in the original list, the number $y$ is exactly the same as the number $x[2]$."

Corrected to:

*"decimal expansion is not unique in the original list, the number $y$ is exactly the same as the number $x[2]$."

This correction makes the sentence more logically consistent and accurate in the context of the mathematical argument.