### PR TITLE
Update gnosis-safe.io links to safe.global

### DIFF
--- a/posts/recovery.md
+++ b/posts/recovery.md
@@ -72,7 +72,7 @@ The best-in-class technology for solving these problems [back in 2013](https://b
 <img src="../../../../images/social-recovery-files/diag1.png" class="padded" />
 </center><br>
 
-This technology was originally developed within the Bitcoin ecosystem, but excellent multisig wallets (eg. see [Gnosis Safe](https://gnosis-safe.io/)) now exist for Ethereum too. Multisig wallets have been highly successful within organizations: the Ethereum Foundation uses a 4-of-7 multisig wallet to store [its funds](https://etherscan.io/address/0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae), as do many other orgs in the Ethereum ecosystem.
+This technology was originally developed within the Bitcoin ecosystem, but excellent multisig wallets (eg. see [Safe (formerly Gnosis Safe)](https://safe.global/)) now exist for Ethereum too. Multisig wallets have been highly successful within organizations: the Ethereum Foundation uses a 4-of-7 multisig wallet to store [its funds](https://etherscan.io/address/0xde0b295669a9fd93d5f28d9ec85e40f4cb697bae), as do many other orgs in the Ethereum ecosystem.
 
 For a multisig wallet to hold the funds for an _individual_, the main challenge is: who holds the funds, and how are transactions approved? The most common formula is some variant of "two easily accessible, but separate, keys, held by you (eg. laptop and phone) and a third more secure but less accessible a backup, held offline or by a friend or institution".
 

--- a/posts/voting2.md
+++ b/posts/voting2.md
@@ -164,7 +164,7 @@ One of the underrated benefits of the crypto space is that it's an excellent "vi
 
 The incentives for attackers are high: if an attacker steals $100 from your cryptoeconomic gadget, they can often get the full $100 in reward, and they can often get away with it. But the incentives for defenders are also high: if you develop a tool that helps users _not_ lose their funds, you could (at least sometimes) turn that into a tool and earn millions. Crypto is the ultimate training zone: if you can build something that can survive in this environment at scale, it can probably also survive in the bigger world as well.
 
-This applies to [quadratic funding](../../../2021/04/02/round9.html), it applies to [multisig](https://gnosis-safe.io/) and [social recovery wallets](../../../2021/01/11/recovery.html), and it can apply to voting systems too. The blockchain space has already helped to motivate the rise of important security technologies:
+This applies to [quadratic funding](../../../2021/04/02/round9.html), it applies to [multisig](https://safe.global/) and [social recovery wallets](../../../2021/01/11/recovery.html), and it can apply to voting systems too. The blockchain space has already helped to motivate the rise of important security technologies:
 
 * Hardware wallets
 * Efficient general-purpose zero knowledge proofs

--- a/posts/voting2_ES.md
+++ b/posts/voting2_ES.md
@@ -164,7 +164,7 @@ Uno de los beneficios subestimados del espacio cripto es que es una excelente "z
 
 Los incentivos para los atacantes son altos: si un atacante roba $100 de tu dispositivo criptoeconómico, a menudo pueden obtener la recompensa completa de $100, y a menudo pueden salir impunes. Pero los incentivos para los defensores también son altos: si desarrollas una herramienta que ayuda a los usuarios a _no_ perder sus fondos, podrías (al menos en ocasiones) convertir eso en una herramienta y ganar millones. Cripto es la zona de entrenamiento definitiva: si puedes construir algo que pueda sobrevivir en este entorno a gran escala, probablemente también pueda sobrevivir en el mundo real.
 
-Esto se aplica a [la financiación cuadrática](../../../2021/04/02/round9.html), se aplica a [multifirmas](https://gnosis-safe.io/) y [carteras de recuperación social](../../../2021/01/11/recovery.html), y también puede aplicarse a los sistemas de votación. El espacio blockchain ya ha contribuido a motivar el surgimiento de tecnologías de seguridad importantes:
+Esto se aplica a [la financiación cuadrática](../../../2021/04/02/round9.html), se aplica a [multifirmas](https://safe.global/) y [carteras de recuperación social](../../../2021/01/11/recovery.html), y también puede aplicarse a los sistemas de votación. El espacio blockchain ya ha contribuido a motivar el surgimiento de tecnologías de seguridad importantes:
 
 * Carteras de hardware
 * Pruebas de conocimiento cero eficientes de propósito general


### PR DESCRIPTION
Hi Vitalik,

Small housekeeping PR. Gnosis Safe rebranded to "Safe" in July 2022 after spinning out from Gnosis as an independent foundation, and the `gnosis-safe.io` domain now 301-redirects to `safe.global`.

This PR updates three posts that link to the legacy domain:

- `posts/recovery.md` (line 75): anchor text updated to "Safe (formerly Gnosis Safe)" with the link pointing to `safe.global`.
- `posts/voting2.md` (line 167) and `posts/voting2_ES.md` (line 167): the anchor text "multisig" / "multifirmas" is preserved, only the URL is swapped from `gnosis-safe.io` to `safe.global`.

The redirect would handle this on its own, but a direct link avoids the extra hop and keeps the brand reference current.

Samuel Akpan
Safe Foundation
